### PR TITLE
Change message listening to be a separate function

### DIFF
--- a/components/mixins/NetlifyPreviewListener.js
+++ b/components/mixins/NetlifyPreviewListener.js
@@ -1,0 +1,21 @@
+function NetlifyPreviewListener(callback){
+  function updateCallback(e){
+    const {action, data} = e.data;
+    if (action === 'render') {
+        callback(data);
+    }
+  }
+
+  window.addEventListener('message', updateCallback)
+
+  function cleanup(){
+    window.removeEventListener('message', updateCallback);
+  }
+
+  window.parent.window.postMessage({action: 'mounted'});
+
+  return cleanup;
+
+}
+
+export default NetlifyPreviewListener;

--- a/components/mixins/NetlifyPreviewMixin.js
+++ b/components/mixins/NetlifyPreviewMixin.js
@@ -1,0 +1,27 @@
+const NetlifyPreviewMixin = (callbackName) => {
+  return {
+    methods: {
+      $updateNetlifyPreview(e) {
+
+      },
+    },
+    created() {
+      if (process.client) {
+        window.addEventListener('message', this.$updateNetlifyPreview)
+      }
+    },
+    mounted() {
+      if (process.client) {
+        window.parent.window.postMessage({action: 'mounted'});
+      }
+    },
+    beforeDestroy() {
+      if (process.client) {
+        window.removeEventListener('message', this.$updateNetlifyPreview);
+      }
+    },
+  };
+}
+
+
+export default NetlifyPreviewMixin;


### PR DESCRIPTION
I've split the message listening to be a separate function. this will allow it to be reused by multiple preview pages. We can also potentially break it out into it's own package.